### PR TITLE
Fix popups not displaying on IE browsers

### DIFF
--- a/assets/js/holler-frontend.js
+++ b/assets/js/holler-frontend.js
@@ -22,7 +22,7 @@
 
   }
 
-  function getUrlParameter( name ) {
+  function hollerGetUrlParameter( name ) {
 
     name = name.replace( /[\[]/, '\\[').replace(/[\]]/, '\\]' );
 
@@ -37,9 +37,9 @@
   // if using the ?hwp_preview=ID query string, show it no matter what
   holler.checkForPreview = function() {
 
-    if( getUrlParameter( 'hwp_preview' ) ) {
+    if( hollerGetUrlParameter( 'hwp_preview' ) ) {
 
-      var id = getUrlParameter( 'hwp_preview' )
+      var id = hollerGetUrlParameter( 'hwp_preview' )
 
       holler.showNote( id );
 

--- a/assets/js/holler-frontend.js
+++ b/assets/js/holler-frontend.js
@@ -8,16 +8,38 @@
     holler.newVisitor = false;
 
     holler.checkForPreview();
-    
+
   }
+
+  // Polyfill for Date.now() on IE
+  if ( ! Date.now ) {
+
+    Date.now = function now() {
+
+      return new Date().getTime();
+
+    };
+
+  }
+
+  function getUrlParameter( name ) {
+
+    name = name.replace( /[\[]/, '\\[').replace(/[\]]/, '\\]' );
+
+    var regex = new RegExp( '[\\?&]' + name + '=([^&#]*)' );
+
+    var results = regex.exec( location.search );
+
+    return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+
+  };
 
   // if using the ?hwp_preview=ID query string, show it no matter what
   holler.checkForPreview = function() {
-    var urlParams = new URLSearchParams(window.location.search);
 
-    if( urlParams.has('hwp_preview') ) {
+    if( getUrlParameter( 'hwp_preview' ) ) {
 
-      var id = urlParams.get('hwp_preview');
+      var id = getUrlParameter( 'hwp_preview' )
 
       holler.showNote( id );
 


### PR DESCRIPTION
This PR fix the issues below on IE browsers.

- `Date.now()` method isn't present on IE 8.
- `URLSearchParams` isn't supported on IE.

